### PR TITLE
removed get_str and added conditional perror

### DIFF
--- a/src/generate_fstab.c
+++ b/src/generate_fstab.c
@@ -26,6 +26,8 @@
 #include <string.h>
 #include <unistd.h>
 
+//#define DEBUGGING
+
 int generate_fstab (char* part, char* fs)
 {
     char* path = "/mnt/etc/fstab";
@@ -38,6 +40,9 @@ int generate_fstab (char* part, char* fs)
     fd = open(path, O_CREAT | O_WRONLY);
 
     if (fd == -1) {
+        #ifdef DEBUGGING
+            perror("Can't open/create fstab, error:");
+        #endif
         return errno;
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -57,19 +57,6 @@
 
 #define SQ_PATH "/run/initramfs/memory/bundles/01-core.sb"
 
-void get_str(int len, char *arr)
-{
-	char ch;
-	register int len_incr = -1;
-	
-	do {
-	    *(arr+len_incr) = ch;
-	    len_incr++;
-    } while((ch=getchar()) != 13 && len_incr < len);
-	
-	*(arr + len) = '\0';
-}
-
 int main (int argc, char** argv)
 {
 


### PR DESCRIPTION
I removed get_str because that cfdisk/fdisk input was removed, so get_str wasn't being used anywhere. I also commented a #define that can trigger a perror whenever -1 is returned upon trying to open or create fstab. Go to commit [d7e168c](https://github.com/Soviet-Linux/revolution-installer/pull/5/commits/d7e168c924dbb7c2f9edbac71d5d7c86f8a12691) to see the macro trigger.